### PR TITLE
Add extra null check in SplitChunksAnalyzerPlugin.ts

### DIFF
--- a/src/plugin/SplitChunksAnalyzerPlugin.ts
+++ b/src/plugin/SplitChunksAnalyzerPlugin.ts
@@ -76,7 +76,7 @@ export class SplitChunksAnalyzerPlugin {
     chainFrom(chunkGroups)
       .filter((chunkGroup) => chunkGroup.chunks.length > 0 || chunkGroup.getChildren().length > 0)
       .forEach((chunkGroup) => {
-        const splitOriginFileName = chunkGroup.origins[0]?.request.split("/");
+        const splitOriginFileName = chunkGroup.origins[0]?.request?.split("/");
         const originName = splitOriginFileName?.[splitOriginFileName.length - 1];
 
         const chunkGroupSize = chainFrom(chunkGroup.getFiles())


### PR DESCRIPTION
`chunkGroup.origins[0]?.request` seems to sometimes be undefined, which causes an error to be thrown when `split` is called. I'm not sure the exact times this happens, but for us, it started when we added a second entrypoint to the webpack config. Adding a safe `?.` operator resolve the issue.